### PR TITLE
catch when window closes unexpectedly

### DIFF
--- a/test/cases/close-without-message/child.html
+++ b/test/cases/close-without-message/child.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body></body>
+<script>
+  //we's bad! no WinChan here!
+  setTimeout(function() {
+    window.close();
+  }, 100);
+</script>
+</html>

--- a/test/cases/close-without-message/run.js
+++ b/test/cases/close-without-message/run.js
@@ -1,0 +1,14 @@
+$(document).ready(function(){
+  asyncTest("open dialog that doesn't properly postMessage when it's done", function() {
+    var argString = (new Date()).toString();
+    WinChan.open({
+      url: "cases/close-without-message/child.html",
+      relay_url: "/relay.html",
+      window_features: "width=700,height=375",
+      params: argString
+    }, function(err, resp) {
+      equal(err, 'unknown closed window');
+      start();
+    });
+  });
+});

--- a/test/index.html
+++ b/test/index.html
@@ -14,6 +14,7 @@
   <script type="text/javascript" src="cases/nav-away/run.js"></script>
   <script type="text/javascript" src="cases/multiple-frame/run.js"></script>
   <script type="text/javascript" src="cases/close-from-inside/run.js"></script>
+  <script type="text/javascript" src="cases/close-without-message/run.js"></script>
 
 </head>
 <body>

--- a/winchan.js
+++ b/winchan.js
@@ -34,7 +34,7 @@
       var userAgent = navigator.userAgent;
       return (userAgent.indexOf('Fennec/') != -1) ||  // XUL
              (userAgent.indexOf('Firefox/') != -1 && userAgent.indexOf('Android') != -1);   // Java
-    } catch(e) {};
+    } catch(e) {}
     return false;
   }
 
@@ -129,12 +129,26 @@
 
         if (!messageTarget) messageTarget = w;
 
+        // lets listen in case the window blows up before telling us
+        var closeInterval = setInterval(function() {
+          if (w && w.closed) {
+            cleanup();
+            if (cb) {
+              cb('unknown closed window');
+              cb = null;
+            }
+          }
+        }, 500);
+
         var req = JSON.stringify({a: 'request', d: opts.params});
 
         // cleanup on unload
         function cleanup() {
           if (iframe) document.body.removeChild(iframe);
           iframe = undefined;
+          if (closeInterval) closeInterval = clearInterval(closeInterval);
+          removeListener(window, 'message', onMessage);
+          removeListener(window, 'unload', cleanup);
           if (w) {
             try {
               w.close();
@@ -154,13 +168,12 @@
             var d = JSON.parse(e.data);
             if (d.a === 'ready') messageTarget.postMessage(req, origin);
             else if (d.a === 'error') {
+              cleanup();
               if (cb) {
                 cb(d.d);
                 cb = null;
               }
             } else if (d.a === 'response') {
-              removeListener(window, 'message', onMessage);
-              removeListener(window, 'unload', cleanup);
               cleanup();
               if (cb) {
                 cb(null, d.d);
@@ -196,7 +209,7 @@
         }
 
         function onMessage(e) {
-          // only one message gets through, but let's make sure it's actually
+          // on)y one message gets through, but let's make sure it's actually
           // the message we're looking for (other code may be using
           // postmessage) - we do this by ensuring the payload can
           // be parsed, and it's got an 'a' (action) value of 'request'.


### PR DESCRIPTION
specifically, if WinChan opens a popup, and the popup doesn't set up
WinChan.onOpen on the other side, then it won't fire a message before
the window closes. We still want to know when the window is closed.

also, cleanup is a little better

addresses mozilla/browserid#1773
