### PR TITLE
Ensure that response was received from expected origin

### DIFF
--- a/winchan.js
+++ b/winchan.js
@@ -165,6 +165,7 @@
 
         function onMessage(e) {
           try {
+            if (e.origin !== origin) { return; }
             var d = JSON.parse(e.data);
             if (d.a === 'ready') messageTarget.postMessage(req, origin);
             else if (d.a === 'error') {


### PR DESCRIPTION
Without this check, it's possible for another window or frame
loaded by the caller of WinChan.open() to send a message that
is interpreted as the WinChan response.

https://bugzilla.mozilla.org/show_bug.cgi?id=868967
