### PR TITLE
Move the origin check out of the try loop

### DIFF
--- a/winchan.js
+++ b/winchan.js
@@ -164,8 +164,8 @@
         addListener(window, 'unload', cleanup);
 
         function onMessage(e) {
+          if (e.origin !== origin) { return; }
           try {
-            if (e.origin !== origin) { return; }
             var d = JSON.parse(e.data);
             if (d.a === 'ready') messageTarget.postMessage(req, origin);
             else if (d.a === 'error') {


### PR DESCRIPTION
There's no reason this check has to be within the try loop. If it
throws an error, it shouldn't be silently swallowed.
