### PR TITLE
Fix origin check for IE10+

### DIFF
--- a/winchan.js
+++ b/winchan.js
@@ -58,7 +58,11 @@
     if (!/^https?:\/\//.test(url)) url = window.location.href;
     var a = document.createElement('a');
     a.href = url;
-    return a.protocol + "//" + a.host;
+
+    var re = {'http:': /:80$/, 'https:': /:443$/, 'ftp:': /:21$/}[a.protocol];
+    var host = re ? a.host.replace(re, '') : a.host;
+
+    return a.protocol + "//" + host;
   }
 
   // find the relay iframe in the opener

--- a/winchan.js
+++ b/winchan.js
@@ -59,7 +59,8 @@
     var a = document.createElement('a');
     a.href = url;
 
-    var re = {'http:': /:80$/, 'https:': /:443$/, 'ftp:': /:21$/}[a.protocol];
+    // remove protocol from evaluated hostname, since IE10+ appends it by default
+    var re = {'http:': /:80$/, 'https:': /:443$/}[a.protocol];
     var host = re ? a.host.replace(re, '') : a.host;
 
     return a.protocol + "//" + host;


### PR DESCRIPTION
The `origin` variable was being filled with port number.

`origin`: `http://my.domain.com:80`
`e.origin`: `http://my.domain.com`

The problem here is that [e.host](https://github.com/mozilla/winchan/blob/ac4b142c34daa84bbcb5d8663fad19ce6394cb18/winchan.js#L61) is returning the port number on IE. Other browsers return just the host name.

``` javascript
var a = document.createElement('a');
a.href = "http://google.com";
a.host // http://google.com:80
```

Tested on IE10 and IE11.
