### PR TITLE
Prevents UA check from breaking in JavaScriptCore/ReactNative

### DIFF
--- a/winchan.js
+++ b/winchan.js
@@ -25,7 +25,7 @@
         rv = parseFloat(RegExp.$1);
     }
     // IE > 11
-    else if (ua.indexOf("Trident") > -1) {
+    else if (typeof ua === 'string' && ua.indexOf("Trident") > -1) {
       var re = new RegExp("rv:([0-9]{2,2}[\.0-9]{0,})");
       if (re.exec(ua) !== null) {
         rv = parseFloat(RegExp.$1);


### PR DESCRIPTION
When running this library from a container that users JSC (like React Native), the IE check breaks because it doesn't have a `navigator.userAgent` value. This causes certain RN-friendly libraries to not run. I've encountered this with [auth0-js](https://github.com/auth0/auth0.js) (which depends on this module) when running it within a React Native app.

(It is ironic that one doesn't normally need to open new windows from within a RN JS VM, but nonetheless the bug still causes a crash).

Creating a polyfill that sets `navigator.userAgent` to any string before importing modules that depend on this works, but this patch is a better solution.